### PR TITLE
Allow resolving of links to repeated headers.

### DIFF
--- a/anchor-markdown-header.js
+++ b/anchor-markdown-header.js
@@ -1,17 +1,45 @@
 'use strict';
 
 // https://github.com/joyent/node/blob/192192a09e2d2e0d6bdd0934f602d2dbbf10ed06/tools/doc/html.js#L172-L183 
-function getNodejsId(text) {
+function getNodejsId(text, repetition) {
   text = text.replace(/[^a-z0-9]+/g, '_');
   text = text.replace(/^_+|_+$/, '');
   text = text.replace(/^([^a-z])/, '_$1');
+
+  // If no repetition, or if the repetition is 0 then ignore. Otherwise append '_' and the number.
+  // An example may be found here: http://nodejs.org/api/domain.html#domain_example_1
+  if (repetition) {
+    text += '_' + repetition;
+  }
+
   return text;
 }
 
-function getGithubId(text) {
-  return text
-    .replace(/ /g,'-')
-    .replace(/[:\[\]`.,()*"]/g,'');
+function basicGithubId(text) {
+  return text.replace(/ /g,'-').replace(/[:\[\]`.,()*"]/g,'');
+}
+
+function getGithubId(text, repetition) {
+  text = basicGithubId(text);
+
+  // If no repetition, or if the repetition is 0 then ignore. Otherwise append '-' and the number.
+  if (repetition) {
+    text += '-' + repetition;
+  }
+
+  return text;
+}
+
+function getBitbucketId(text, repetition) {
+  text = 'markdown-header-' + basicGithubId(text);
+
+  // If no repetition, or if the repetition is 0 then ignore. Otherwise append '_' and the number.
+  // https://groups.google.com/d/msg/bitbucket-users/XnEWbbzs5wU/Fat0UdIecZkJ
+  if (repetition) {
+    text += '_' + repetition;
+  }
+
+  return text;
 }
 
 /**
@@ -21,10 +49,11 @@ function getGithubId(text) {
  * @function
  * @param header      {String} The header to be anchored.
  * @param mode        {String} The anchor mode ('github.com'|'nodejs.org|bitbucket.org').
+ * @param repetition  {Number} The nth occurrence of this header text, starting with 0. Not required for the 0th instance.
  * @param moduleName  {String} The name of the module of the given header (required only for 'nodejs.org' mode).
  * @return            {String} The header anchor that is compatible with the given mode.
-  */
-module.exports = function anchorMarkdownHeader(header, mode, moduleName) {
+ */
+module.exports = function anchorMarkdownHeader(header, mode, repetition, moduleName) {
   mode = mode || 'github.com';
   var replace;
 
@@ -33,21 +62,19 @@ module.exports = function anchorMarkdownHeader(header, mode, moduleName) {
       replace = getGithubId;
       break;
     case 'bitbucket.org':
-      replace = function (text) { 
-        return 'markdown-header-' + getGithubId(text); 
-      };
+      replace = getBitbucketId;
       break;
-    case 'nodejs.org': 
+    case 'nodejs.org':
       if (!moduleName) throw new Error('Need module name to generate proper anchor for ' + mode);
-      replace = function (hd) {
-          return getNodejsId(moduleName + '.' + hd);
+      replace = function (hd, repetition) {
+          return getNodejsId(moduleName + '.' + hd, repetition);
       };
       break;
     default:
       throw new Error('Unknown mode: ' + mode);
   }
 
-  var href = replace(header.trim().toLowerCase());
+  var href = replace(header.trim().toLowerCase(), repetition);
 
   return '[' + header + '](#' + href + ')';
 };

--- a/test/anchor-markdown-header.js
+++ b/test/anchor-markdown-header.js
@@ -5,54 +5,59 @@ var test   =  require('trap').test
   , format =  require('util').format
   , anchor =  require('..')
 
-function checkResult(t, mode, moduleName, header, href) {
+function checkResult(t, mode, moduleName, header, repetition, href) {
   var expectedAnchor = format('[%s](%s)', header, href)
-  t.equal(anchor(header, mode, moduleName), expectedAnchor, format('generates "%s" for header "%s"', expectedAnchor, header));
+  var resultText = 'generates ' + expectedAnchor + ' for header ' + header + ' and repetition = ' + repetition; 
+  t.equal(anchor(header, mode, repetition, moduleName), expectedAnchor, resultText);
 }
-  
+
 test('generating anchor in github mode', function (t) {
 
   var check = checkResult.bind(null, t, undefined, undefined);
 
-  [ [ 'intro',  '#intro' ]
-  , [ 'mineflayer.windows.Window (base class)',  '#mineflayerwindowswindow-base-class']
-  , [ 'window.findInventoryItem(itemType, metadata, [notFull])', '#windowfindinventoryitemitemtype-metadata-notfull' ]
-  , [ 'furnace "updateSlot" (oldItem, newItem)', '#furnace-updateslot-olditem-newitem' ]
-  , [ '"playerJoined" (player)', '#playerjoined-player' ]
-  , [ 'proxyquire(request: String, stubs: Object)', '#proxyquirerequest-string-stubs-object' ]
-  ].forEach(function (x) { check(x[0], x[1]) });
-  
+  [ [ 'intro', null,  '#intro' ]
+  , [ 'intro', 0,  '#intro' ]
+  , [ 'intro', 1,  '#intro-1' ]
+  , [ 'mineflayer.windows.Window (base class)', null,  '#mineflayerwindowswindow-base-class']
+  , [ 'window.findInventoryItem(itemType, metadata, [notFull])', null, '#windowfindinventoryitemitemtype-metadata-notfull' ]
+  , [ 'furnace "updateSlot" (oldItem, newItem)', null, '#furnace-updateslot-olditem-newitem' ]
+  , [ '"playerJoined" (player)', null, '#playerjoined-player' ]
+  , [ 'proxyquire(request: String, stubs: Object)', null, '#proxyquirerequest-string-stubs-object' ]
+  ].forEach(function (x) { check(x[0], x[1], x[2]) });
 })
 
 test('generating anchor in nodejs.org mode for fs module', function (t) {
 
   var check = checkResult.bind(null, t, 'nodejs.org', 'fs');
 
-  [ [ 'fs.rename(oldPath, newPath, [callback])', '#fs_fs_rename_oldpath_newpath_callback' ] 
-  , [ 'fs.truncate(fd, len, [callback])', '#fs_fs_truncate_fd_len_callback' ]
-  , [ 'fs.symlink(srcpath, dstpath, [type], [callback])', '#fs_fs_symlink_srcpath_dstpath_type_callback' ]
-  , [ "fs.appendFile(filename, data, encoding='utf8', [callback])", '#fs_fs_appendfile_filename_data_encoding_utf8_callback' ]
-  , [ 'Class: fs.FSWatcher', '#fs_class_fs_fswatcher' ]
-  ].forEach(function (x) { check(x[0], x[1]) });
-  
+  [ [ 'fs.rename(oldPath, newPath, [callback])', null, '#fs_fs_rename_oldpath_newpath_callback' ]
+  , [ 'fs.rename(oldPath, newPath, [callback])', 0, '#fs_fs_rename_oldpath_newpath_callback' ]
+  , [ 'fs.rename(oldPath, newPath, [callback])', 1, '#fs_fs_rename_oldpath_newpath_callback_1' ] 
+  , [ 'fs.truncate(fd, len, [callback])', null, '#fs_fs_truncate_fd_len_callback' ]
+  , [ 'fs.symlink(srcpath, dstpath, [type], [callback])', null, '#fs_fs_symlink_srcpath_dstpath_type_callback' ]
+  , [ "fs.appendFile(filename, data, encoding='utf8', [callback])", null, '#fs_fs_appendfile_filename_data_encoding_utf8_callback' ]
+  , [ 'Class: fs.FSWatcher', null, '#fs_class_fs_fswatcher' ]
+  ].forEach(function (x) { check(x[0], x[1], x[2]) });
 })
 
 test('generating anchor in nodejs.org mode for crypto module', function (t) {
 
   var check = checkResult.bind(null, t, 'nodejs.org', 'crypto');
 
-  [ [ 'cipher.update(data, [input_encoding], [output_encoding])', '#crypto_cipher_update_data_input_encoding_output_encoding' ]
-  , [ 'crypto.pbkdf2(password, salt, iterations, keylen, callback)' , '#crypto_crypto_pbkdf2_password_salt_iterations_keylen_callback' ]
-  ].forEach(function (x) { check(x[0], x[1]) });
+  [ [ 'cipher.update(data, [input_encoding], [output_encoding])', null, '#crypto_cipher_update_data_input_encoding_output_encoding' ]
+  , [ 'crypto.pbkdf2(password, salt, iterations, keylen, callback)', null, '#crypto_crypto_pbkdf2_password_salt_iterations_keylen_callback' ]
+  ].forEach(function (x) { check(x[0], x[1], x[2]) });
 })
 
 test('generating anchor in bitbucket mode', function (t) {
 
   var check = checkResult.bind(null, t, 'bitbucket.org', undefined);
 
-  [ [ 'intro',  '#markdown-header-intro' ]
-  , [ 'mineflayer.windows.Window (base class)',  '#markdown-header-mineflayerwindowswindow-base-class']
-  , [ 'proxyquire(request: String, stubs: Object)', '#markdown-header-proxyquirerequest-string-stubs-object' ]
-  ].forEach(function (x) { check(x[0], x[1]) });
-  
+  [ [ 'intro', null, '#markdown-header-intro' ]
+  , [ 'intro', 0, '#markdown-header-intro' ]
+  , [ 'intro', 1, '#markdown-header-intro_1' ]
+  , [ 'mineflayer.windows.Window (base class)', null, '#markdown-header-mineflayerwindowswindow-base-class']
+  , [ 'proxyquire(request: String, stubs: Object)', null, '#markdown-header-proxyquirerequest-string-stubs-object' ]
+  ].forEach(function (x) { check(x[0], x[1], x[2]) });
 })
+


### PR DESCRIPTION
In the case of multiple headings with the same text, there was no way of linking to anything but the first heading. This PR allows the resolving of the 0th (as before) but also the 1st 2nd and so on as an optional argument.

This is required for a pull request that I'll submit to doctoc to automatically handle multiple identical headings.
