### PR TITLE
Adding a 'github wiki' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ anchor('"playerJoined" (player)') === anchor('"playerJoined" (player)', 'github.
  * @name anchorMarkdownHeader
  * @function
  * @param header      {String} The header to be anchored.
- * @param mode        {String} The anchor mode ('github.com'|'nodejs.org|bitbucket.org').
+ * @param mode        {String} The anchor mode ('github.com'|'github.com/wiki'|'nodejs.org'|'bitbucket.org').
  * @param repetition  {Number} The nth occurrence of this header text, starting with 0. Not required for the 0th instance.
  * @param moduleName  {String} The name of the module of the given header (required only for 'nodejs.org' mode).
  * @return            {String} The header anchor that is compatible with the given mode.

--- a/anchor-markdown-header.js
+++ b/anchor-markdown-header.js
@@ -42,13 +42,21 @@ function getBitbucketId(text, repetition) {
   return "#" + text;
 }
 
+function getGithubWikiId(text, repetition) {
+    text = getGithubId(text, repetition);
+
+    // GitHub wikis rewrite links to "#foo" as "#wiki-foo", so we work
+    // around that by specifying empty query parameters too.
+    return "?" + text;
+}
+
 /**
  * Generates an anchor for the given header and mode.
  * 
  * @name anchorMarkdownHeader
  * @function
  * @param header      {String} The header to be anchored.
- * @param mode        {String} The anchor mode ('github.com'|'nodejs.org|bitbucket.org').
+ * @param mode        {String} The anchor mode ('github.com'|'github.com/wiki'|'nodejs.org'|'bitbucket.org').
  * @param repetition  {Number} The nth occurrence of this header text, starting with 0. Not required for the 0th instance.
  * @param moduleName  {String} The name of the module of the given header (required only for 'nodejs.org' mode).
  * @return            {String} The header anchor that is compatible with the given mode.
@@ -60,6 +68,9 @@ module.exports = function anchorMarkdownHeader(header, mode, repetition, moduleN
   switch(mode) {
     case 'github.com':
       replace = getGithubId;
+      break;
+    case 'github.com/wiki':
+      replace = getGithubWikiId;
       break;
     case 'bitbucket.org':
       replace = getBitbucketId;

--- a/test/anchor-markdown-header.js
+++ b/test/anchor-markdown-header.js
@@ -28,6 +28,15 @@ test('generating anchor in github mode', function (t) {
   ].forEach(function (x) { check(x[0], x[1], x[2]) });
 })
 
+test('generating anchor in github wiki mode', function (t) {
+
+  var check = checkResult.bind(null, t, "github wiki", undefined);
+
+  [ [ 'intro', null,  '?#intro' ]
+  , [ 'intro', 0,  '?#intro' ]
+  ].forEach(function (x) { check(x[0], x[1], x[2]) });
+})
+
 test('generating anchor in nodejs.org mode for fs module', function (t) {
 
   var check = checkResult.bind(null, t, 'nodejs.org', 'fs');


### PR DESCRIPTION
Following the discussion in thlorenz/doctoc#21 and thlorenz/doctoc#22, here's a patch for 'github wiki' style anchors. Let me know what you think, I wasn't sure what to call the mode.
