### PR TITLE
add support for links generated by Ghost.org Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ anchor('"playerJoined" (player)') === anchor('"playerJoined" (player)', 'github.
  * @name anchorMarkdownHeader
  * @function
  * @param header      {String} The header to be anchored.
- * @param mode        {String} The anchor mode (github.com|nodejs.org|bitbucket.org|gitlab.com).
+ * @param mode        {String} The anchor mode (github.com|nodejs.org|bitbucket.org|ghost.org|gitlab.com).
  * @param repetition  {Number} The nth occurrence of this header text, starting with 0. Not required for the 0th instance.
  * @param moduleName  {String} The name of the module of the given header (required only for 'nodejs.org' mode).
  * @return            {String} The header anchor that is compatible with the given mode.

--- a/anchor-markdown-header.js
+++ b/anchor-markdown-header.js
@@ -48,6 +48,26 @@ function getBitbucketId(text, repetition) {
   return text;
 }
 
+function basicGhostId(text) {
+  return text.replace(/ /g,'')
+    // escape codes are not removed
+    // single chars that are removed
+    .replace(/[\/?:\[\]`.,()*"';{}\-+=<>!@#%^&\\\|]/g,'')
+    // $ replaced with d
+    .replace(/\$/g, 'd')
+    // ~ replaced with t
+    .replace(/~/g, 't')
+    ;
+}
+
+function getGhostId(text) {
+  text = basicGhostId(text);
+
+  // Repetitions not supported
+
+  return text;
+}
+
 // see: https://github.com/gitlabhq/gitlabhq/blob/master/doc/markdown/markdown.md#header-ids-and-links
 function getGitlabId(text, repetition) {
   return text
@@ -67,7 +87,7 @@ function getGitlabId(text, repetition) {
  * @name anchorMarkdownHeader
  * @function
  * @param header      {String} The header to be anchored.
- * @param mode        {String} The anchor mode (github.com|nodejs.org|bitbucket.org|gitlab.com).
+ * @param mode        {String} The anchor mode (github.com|nodejs.org|bitbucket.org|ghost.org|gitlab.com).
  * @param repetition  {Number} The nth occurrence of this header text, starting with 0. Not required for the 0th instance.
  * @param moduleName  {String} The name of the module of the given header (required only for 'nodejs.org' mode).
  * @return            {String} The header anchor that is compatible with the given mode.
@@ -91,6 +111,9 @@ module.exports = function anchorMarkdownHeader(header, mode, repetition, moduleN
       replace = function (hd, repetition) {
           return getNodejsId(moduleName + '.' + hd, repetition);
       };
+      break;
+    case 'ghost.org':
+      replace = getGhostId;
       break;
     default:
       throw new Error('Unknown mode: ' + mode);

--- a/test/anchor-markdown-header.js
+++ b/test/anchor-markdown-header.js
@@ -35,6 +35,32 @@ test('\ngenerating anchor in github mode', function (t) {
   t.end();
 })
 
+test('\ngenerating anchor in ghost mode', function (t) {
+
+  var check = checkResult.bind(null, t, 'ghost.org', undefined);
+
+  [ [ 'intro', null,  '#intro' ]
+  , [ 'intro', 0,  '#intro' ]
+  , [ 'repetitions not supported', 1,  '#repetitionsnotsupported' ]
+  , [ 'mineflayer.windows.Window (base class)', null,  '#mineflayerwindowswindowbaseclass']
+  , [ 'window.findInventoryItem(itemType, metadata, [notFull])', null, '#windowfindinventoryitemitemtypemetadatanotfull' ]
+  , [ 'furnace "updateSlot" (oldItem, newItem)', null, '#furnaceupdateslotolditemnewitem' ]
+  , [ '"playerJoined" (player)', null, '#playerjoinedplayer' ]
+  , [ 'proxyquire(request: String, stubs: Object)', null, '#proxyquirerequeststringstubsobject' ],
+  , [ 'create object (post /db/create)', null, '#createobjectpostdbcreate' ]
+  , [ 'where is it?', null, '#whereisit' ]
+  , [ "'webdav' Upload Method for 'dput'", null, '#webdavuploadmethodfordput' ]
+  , [ 'remove ;;semi;colons', null, '#removesemicolons' ],
+  , [ 'remove {curly braces}{}', null, '#removecurlybraces'],
+  , [ 'remove ++++pluses+', null, '#removepluses']
+  , [ 'does not remove escape codes instead removes % as in %3Cstatic%E3 %86 %3Cstatic%E3 coreappupevents %E2%86%92 object', null, '#doesnotremoveescapecodesinsteadremovesasin3cstatice3863cstatice3coreappupeventse28692object']
+  , [ 'remove lt and gt <static>mycall', null, '#removeltandgtstaticmycall']
+  , [ 'remove special chars `!@#%^&*()-+=[{]}\\|;:\'\",<.>/?', null, '#removespecialchars']
+  , [ 'replace $ with d and ~ with t', null, '#replacedwithdandtwitht']
+  ].forEach(function (x) { check(x[0], x[1], x[2]) });
+  t.end();
+})
+
 test('\ngenerating anchor in nodejs.org mode for fs module', function (t) {
 
   var check = checkResult.bind(null, t, 'nodejs.org', 'fs');


### PR DESCRIPTION
Ghost Markdown creates its own weird flavor of IDs, different from GitHub. With the platform increasing in prevalence, adding support would be beneficial to the library. 

Differences:

* Spaces deleted, not replaced by `-`
* Repetitions of headers not supported.
* `$` translates to `d`
* `~` translates to `t`
* Escape characters not escaped
* Nearly full range of symbols are deleted; only `_` is kept

Below is an example of anchor IDs generated by Ghost from a markdown source.


![screen shot 2015-01-11 at 9 21 30 pm](https://cloud.githubusercontent.com/assets/5187404/5699258/efb2fbd2-99d7-11e4-8d5e-9d8844413a8f.png)


