### PR TITLE
Handle gitlab markup for non-alpha headers

### DIFF
--- a/anchor-markdown-header.js
+++ b/anchor-markdown-header.js
@@ -77,7 +77,8 @@ function getGitlabId(text, repetition) {
     .replace(/<(.*)>(.*)<\/\1>/g,"$2") // html tags
     .replace(/!\[.*\]\(.*\)/g,'')      // image tags
     .replace(/\[(.*)\]\(.*\)/,"$1")    // url
-    .replace(/[^a-z0-9_-]/g,'-')       // non alpha
+    .replace(/[^a-z0-9_-\s]/g,'')       // non alpha
+    .replace(/[\s]/g,'-')              // spaces
     .replace(/[-]+/g,'-')              // duplicated hyphen
     .replace(/^-/,'')                  // ltrim hyphen
     .replace(/-$/,'');                 // rtrim hyphen

--- a/test/anchor-markdown-header.js
+++ b/test/anchor-markdown-header.js
@@ -117,7 +117,7 @@ test('\ngenerating anchor in gitlab mode', function (t) {
 
   [ [ 'intro', null, '#intro']
   , [ 'intro', 1, '#intro']
-  , ['..Ab_c-d. e [anchor](url) ![alt text](url)..', null, '#ab_c-d-e-anchor']
+  , ['..A.b_c-d- e [anchor](url) ![alt text](url)..', null, '#ab_c-d-e-anchor']
   ].forEach(function (x) { check(x[0], x[1], x[2]) });
   t.end();
 })


### PR DESCRIPTION
Gitlab markup's rule for non alpha characters was not properly handled.  They were being replaced with hyphens, not removed.
https://github.com/gitlabhq/gitlabhq/blob/master/doc/markdown/markdown.md#header-ids-and-links