### PR TITLE
Add m-dash and n-dash, they are replaced with - by GitHub.

### DIFF
--- a/anchor-markdown-header.js
+++ b/anchor-markdown-header.js
@@ -20,7 +20,7 @@ function basicGithubId(text) {
     // escape codes
     .replace(/%([abcdef]|\d){2,2}/ig, '')
     // single chars that are removed
-    .replace(/[\/?!:\[\]`.,()*"';{}+=<>~\$|#]/g,'')
+    .replace(/[\/?!:\[\]`.,()*"';{}+=<>~\$|#–—]/g,'')
     ;
           
 }

--- a/test/anchor-markdown-header.js
+++ b/test/anchor-markdown-header.js
@@ -39,6 +39,7 @@ test('\ngenerating anchor in github mode', function (t) {
   , [ 'class~method', null, '#classmethod']
   , [ 'func($event)', null, '#funcevent']
   , [ 'trailing *', null, '#trailing-']
+  , [ 'replace – or —', null, '#replace--or-']
   ].forEach(function (x) { check(x[0], x[1], x[2]) });
   t.end();
 })


### PR DESCRIPTION
Added m-dash (`—`) and n-dash (`–`), as they are replaced with `-` by GitHub.