### PR TITLE
Replace @ character with empty string

### DIFF
--- a/anchor-markdown-header.js
+++ b/anchor-markdown-header.js
@@ -20,7 +20,7 @@ function basicGithubId(text) {
     // escape codes
     .replace(/%([abcdef]|\d){2,2}/ig, '')
     // single chars that are removed
-    .replace(/[\/?!:\[\]`.,()*"';{}+=<>~\$|#]/g,'')
+    .replace(/[\/?!:\[\]`.,()*"';{}+=<>~\$|#@]/g,'')
     ;
           
 }

--- a/test/anchor-markdown-header.js
+++ b/test/anchor-markdown-header.js
@@ -39,6 +39,8 @@ test('\ngenerating anchor in github mode', function (t) {
   , [ 'class~method', null, '#classmethod']
   , [ 'func($event)', null, '#funcevent']
   , [ 'trailing *', null, '#trailing-']
+  , [ 'My Cool@Header', null, '#my-coolheader']
+  , [ 'module-specific-variables-using-jsdoc-@module', null, '#module-specific-variables-using-jsdoc-module']
   ].forEach(function (x) { check(x[0], x[1], x[2]) });
   t.end();
 })


### PR DESCRIPTION
From thlorenz/doctoc#104:

> When you use `@` in a header, doctoc should remove it in the link as GitHub does.
>
> Example:
>
> ```md
> <!-- START doctoc generated TOC please keep comment here to allow auto update -->
> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
> **Table of Contents**
>
> - [My Cool@Header](#my-coolheader)
> <!-- END doctoc generated TOC please keep comment here to allow auto update -->
>
>
> ## My Cool@Header
>
> ```
>
> Instead it is currently creating a link like: `[My Cool@Header](#my-cool@header)`

This pull request adds `@` to the list of characters we strip, and tests it.