### PR TITLE
fix anchor header repetition issue for gitlab mode

### DIFF
--- a/anchor-markdown-header.js
+++ b/anchor-markdown-header.js
@@ -73,7 +73,7 @@ function getGhostId(text) {
 
 // see: https://github.com/gitlabhq/gitlabhq/blob/master/doc/markdown/markdown.md#header-ids-and-links
 function getGitlabId(text, repetition) {
-  return text
+  text = text
     .replace(/<(.*)>(.*)<\/\1>/g,"$2") // html tags
     .replace(/!\[.*\]\(.*\)/g,'')      // image tags
     .replace(/\[(.*)\]\(.*\)/,"$1")    // url
@@ -81,6 +81,11 @@ function getGitlabId(text, repetition) {
     .replace(/[-]+/g,'-')              // duplicated hyphen
     .replace(/^-/,'')                  // ltrim hyphen
     .replace(/-$/,'');                 // rtrim hyphen
+  // If no repetition, or if the repetition is 0 then ignore. Otherwise append '-' and the number.
+  if (repetition) {
+    text += '-' + repetition;
+  }
+  return text;
 }
 
 

--- a/test/anchor-markdown-header.js
+++ b/test/anchor-markdown-header.js
@@ -119,7 +119,8 @@ test('\ngenerating anchor in gitlab mode', function (t) {
   var check = checkResult.bind(null, t, 'gitlab.com', undefined);
 
   [ [ 'intro', null, '#intro']
-  , [ 'intro', 1, '#intro']
+  , [ 'intro', 0, '#intro']
+  , [ 'intro', 1, '#intro-1']
   , ['..Ab_c-d. e [anchor](url) ![alt text](url)..', null, '#ab_c-d-e-anchor']
   ].forEach(function (x) { check(x[0], x[1], x[2]) });
   t.end();


### PR DESCRIPTION
When multi-header with the same name exists, the generated anchor in toc does not have a repetition number for gitlab mode.
eg:

```
# some-head
# some-head

// and refer to: https://github.com/gitlabhq/gitlabhq/blob/master/doc/markdown/markdown.md#header-ids-and-links
//the generated toc should be

- [some-head](#some-head)
- [some-head](#some-head-1)
```