### PR TITLE
Remove all html tags from the GitHub's anchor tag.

### DIFF
--- a/anchor-markdown-header.js
+++ b/anchor-markdown-header.js
@@ -21,6 +21,8 @@ function basicGithubId(text) {
   return text.replace(/ /g,'-')
     // escape codes
     .replace(/%([abcdef]|\d){2,2}/ig, '')
+    // html tags that are removed
+    .replace(/(<([^>]+)>)/gi, '')
     // single chars that are removed
     .replace(/[\/?!:\[\]`.,()*"';{}+=<>~\$|#@&–—]/g,'')
     // CJK punctuations that are removed

--- a/test/anchor-markdown-header.js
+++ b/test/anchor-markdown-header.js
@@ -30,7 +30,7 @@ test('\ngenerating anchor in github mode', function (t) {
   , [ 'remove {curly braces}{}', null, '#remove-curly-braces'],
   , [ 'remove ++++pluses+', null, '#remove-pluses']
   , [ 'remove escape codes %3Cstatic%E3 coreappupevents %E2%86%92 object', null, '#remove-escape-codes-static-coreappupevents--object']
-  , [ 'remove lt and gt <static>mycall', null, '#remove-lt-and-gt-staticmycall']
+  , [ 'remove lt and gt <static>mycall', null, '#remove-lt-and-gt-mycall']
   , [ 'remove exclamation point!', null, '#remove-exclamation-point']
   , [ 'remove = sign', null, '#remove--sign']
   , [ '`history [pgn | alg]`', null, '#history-pgn--alg']


### PR DESCRIPTION
HTML tags should be removed from the GitHub's anchor tag. See below:  
```
- [Heading test with<sup>HTML tags</sup>](#heading-test-withhtml-tags)
...
# Heading test with<sup>HTML tags</sup>
```