### PR TITLE
Fix problem related to zwj characters in emojis

### DIFF
--- a/anchor-markdown-header.js
+++ b/anchor-markdown-header.js
@@ -112,10 +112,18 @@ function getGitlabId(text, repetition) {
 module.exports = function anchorMarkdownHeader(header, mode, repetition, moduleName) {
   mode = mode || 'github.com';
   var replace;
+  var customEncodeURI = encodeURI;
 
   switch(mode) {
     case 'github.com':
       replace = getGithubId;
+      customEncodeURI = function(uri) {
+        var newURI = encodeURI(uri);
+        
+        // encodeURI replaces the zwj character (used to generate emoji sequences, i.e. Female Construction Worker 👷🏼‍♀️)
+        // github doesn't URL encode them so replace them after url encoding to preserve the zwj character.
+        return newURI.replace(/%E2%80%8D/g, '\u200D');
+      };
       break;
     case 'bitbucket.org':
       replace = getBitbucketId;
@@ -150,5 +158,5 @@ module.exports = function anchorMarkdownHeader(header, mode, repetition, moduleN
 
   var href = replace(asciiOnlyToLowerCase(header.trim()), repetition);
 
-  return '[' + header + '](#' + encodeURI(href) + ')';
+  return '[' + header + '](#' + customEncodeURI(href) + ')';
 };

--- a/anchor-markdown-header.js
+++ b/anchor-markdown-header.js
@@ -119,9 +119,10 @@ module.exports = function anchorMarkdownHeader(header, mode, repetition, moduleN
       replace = getGithubId;
       customEncodeURI = function(uri) {
         var newURI = encodeURI(uri);
-        
-        // encodeURI replaces the zwj character (used to generate emoji sequences, i.e. Female Construction Worker 👷🏼‍♀️)
-        // github doesn't URL encode them so replace them after url encoding to preserve the zwj character.
+
+        // encodeURI replaces the zero width joiner character
+        // (used to generate emoji sequences, e.g.Female Construction Worker 👷🏼‍♀️)
+        // github doesn't URL encode them, so we replace them after url encoding to preserve the zwj character.
         return newURI.replace(/%E2%80%8D/g, '\u200D');
       };
       break;

--- a/test/anchor-markdown-header.js
+++ b/test/anchor-markdown-header.js
@@ -46,6 +46,7 @@ test('\ngenerating anchor in github mode', function (t) {
   , [ 'Modules 📦', null, '#modules-']
   , [ 'Modu📦les', null, '#modules']
   , [ 'Mo📦du📦les', null, '#modules']
+  , [ '👷🏼‍♀️ Maintenance', null, '#\u200D-maintenance']
   ].forEach(function (x) { check(x[0], x[1], x[2]) });
   t.end();
 })


### PR DESCRIPTION
This fixes a problem with the zwj character and headings which contain emoji sequences.

An example of the bug can be seen in the [👷🏼‍♀️ Mainenance link](https://github.com/neontribe/www/tree/0b8a8c85bcb9c39018ddcfc24df28879c10c81a0#neontribe-website). 

Github seems to leave the `\u200D` chracter un-encoded in the links, so when you click the `[👷🏼‍♀️ Maintenance](#%E2%80%8D-maintenance)` link above it doesn't jump to the correct place in the page.

This fix just makes sure that it works on github, I haven't tested it on the other MD renderers, so I was more defensive with the change.