### PR TITLE
Migrate to Actions for CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,29 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+
+    - run: npm install
+
+    - run: npm test

--- a/.taprc
+++ b/.taprc
@@ -1,0 +1,4 @@
+statements: 96
+lines: 98
+functions: 100
+branches: 90

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - 0.8
-  - 0.10

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "gitHead": "dcde154040d17d321664a7efc38e8531330335f9",
+  "tap": {
+    "statements": 96,
+    "lines": 98,
+    "functions": 100,
+    "branches": 90
+  },
   "devDependencies": {
     "tap": "~0.4.8"
   },

--- a/package.json
+++ b/package.json
@@ -22,12 +22,6 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "gitHead": "dcde154040d17d321664a7efc38e8531330335f9",
-  "tap": {
-    "statements": 96,
-    "lines": 98,
-    "functions": 100,
-    "branches": 90
-  },
   "devDependencies": {
     "tap": "~0.4.8"
   },


### PR DESCRIPTION
I figured with https://github.com/thlorenz/doctoc/pull/231 and https://github.com/thlorenz/doctoc/issues/227#issuecomment-1191021455 this would be a welcome change as well!

These are passing as well: https://github.com/kevin-david/anchor-markdown-header/pull/2/checks