### PR TITLE
fix: Add additional characters to be removed

### DIFF
--- a/anchor-markdown-header.js
+++ b/anchor-markdown-header.js
@@ -26,6 +26,8 @@ function basicGithubId(text) {
     .replace(/[\/\\?!%:\[\]`.,()*"';{}+=<>~\$|#@&–—]/g,'')
     // CJK punctuations that are removed
     .replace(/[。？！，、；：“”【】（）〔〕［］﹃﹄“ ”‘’﹁﹂—…－～《》〈〉「」]/g, '')
+    // latin-1 supplement chars that are removed
+    .replace(/[¡¢£¤¥¦§¨©«¬®¯±²³´¶·¸¹º»¼½¾¿]/g, '')
     ;
 
 }
@@ -91,6 +93,7 @@ function getGitlabId(text, repetition) {
     .replace(/\s+/g, '-')              // All spaces are converted to hyphens
     .replace(/[\/?!:\[\]`.,()*"';{}+=<>~\$|#@]/g,'') // All non-word text (e.g., punctuation, HTML) is removed
     .replace(/[。？！，、；：“”【】（）〔〕［］﹃﹄“ ”‘’﹁﹂—…－～《》〈〉「」]/g, '') // remove CJK punctuations
+    .replace(/[¹²³]/g, '') // remove snall subset of latin-1 supplement chars
     .replace(/[-]+/g,'-')              // duplicated hyphen
     .replace(/^-/,'')                  // ltrim hyphen
     .replace(/-$/,'');                 // rtrim hyphen

--- a/test/anchor-markdown-header.js
+++ b/test/anchor-markdown-header.js
@@ -78,6 +78,7 @@ test('\ngenerating anchor in github mode', function (t) {
   , [ '_foo_bax_', null, '#foo_bax']
   , [ '10% off', null, '#10-off']
   , [ '1/2 affected', null, '#12-affected']
+  , [ '¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿Latin 1', null, '#%C2%AA%C2%B0%C2%B5latin-1']
 
   ].forEach(function (x) { check(x[0], x[1], x[2]) });
   t.end();


### PR DESCRIPTION
Closes #51 

Is blocking: https://github.com/thlorenz/doctoc/pull/300

Remove both % & \ from id's as required by github/ Also most latin-1 supplement characters are removed.