### PR TITLE
feat: Add custom mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ anchor('"playerJoined" (player)') === anchor('"playerJoined" (player)', 'github.
 
 ## API
 
-`anchor(header[, mode] [, repetition)`
+`anchor(header[, mode] [, repetition] [, href])`
 
 ```js
 /**
@@ -29,6 +29,7 @@ anchor('"playerJoined" (player)') === anchor('"playerJoined" (player)', 'github.
  * @param header      {String} The header to be anchored.
  * @param mode        {String} The anchor mode (github.com|nodejs.org|bitbucket.org|ghost.org|gitlab.com).
  * @param repetition  {Number} The nth occurrence of this header text, starting with 0. Not required for the 0th instance.
+ * @param href        {String} The href to be used in the anchor.
  * @return            {String} The header anchor that is compatible with the given mode.
  */
 ```

--- a/anchor-markdown-header.js
+++ b/anchor-markdown-header.js
@@ -116,9 +116,10 @@ function getGitlabId(text, repetition) {
  * @param header      {String} The header to be anchored.
  * @param mode        {String} The anchor mode (github.com|nodejs.org|bitbucket.org|ghost.org|gitlab.com).
  * @param repetition  {Number} The nth occurrence of this header text, starting with 0. Not required for the 0th instance.
+ * @param href        {String} The href to be used in the anchor.
  * @return            {String} The header anchor that is compatible with the given mode.
  */
-module.exports = function anchorMarkdownHeader(header, mode, repetition) {
+module.exports = function anchorMarkdownHeader(header, mode, repetition, href) {
   mode = mode || 'github.com';
   var replace;
   var customEncodeURI = encodeURI;
@@ -152,6 +153,11 @@ module.exports = function anchorMarkdownHeader(header, mode, repetition) {
     case 'ghost.org':
       replace = getGhostId;
       break;
+    case 'custom':
+      if(href === undefined){
+        throw new Error('Missing href');
+      }
+      break;
     default:
       throw new Error('Unknown mode: ' + mode);
   }
@@ -168,7 +174,7 @@ module.exports = function anchorMarkdownHeader(header, mode, repetition) {
     return result;
   }
 
-  var href = replace(customCasing(header.trim()), repetition);
+  href = href || replace(customCasing(header.trim()), repetition);
 
   return '[' + header + '](#' + customEncodeURI(href) + ')';
 };

--- a/test/anchor-markdown-header.js
+++ b/test/anchor-markdown-header.js
@@ -189,13 +189,23 @@ test('\ngenerating anchor for non-english header', function (t) {
 })
 
 test('\ngenerating anchor in custom mode', function (t) {
-  var actual = anchor('custom', 'Heading Text', 0, 'head');
+  var actual = anchor('Heading Text', 'custom', 0, 'head');
   var expectedAnchor = '[Heading Text](#head)';
   t.equal(actual, expectedAnchor);
+  t.end();
 })
 
 test('\ngenerating anchor in github mode with href', function (t) {
-  var actual = anchor('github', 'Heading Text', 1, 'head');
+  var actual = anchor('Heading Text', 'github.com', 1, 'head');
   var expectedAnchor = '[Heading Text](#head)';
   t.equal(actual, expectedAnchor);
+  t.end();
+})
+
+test('\nmissing input for custom mode throws', function (t) {
+  t.throws(
+    () => anchor('Heading Text', 'github.com', 0),
+    { message: 'Missing href' }
+  );
+  t.end();
 })

--- a/test/anchor-markdown-header.js
+++ b/test/anchor-markdown-header.js
@@ -204,8 +204,16 @@ test('\ngenerating anchor in github mode with href', function (t) {
 
 test('\nmissing input for custom mode throws', function (t) {
   t.throws(
-    () => anchor('Heading Text', 'github.com', 0),
+    () => anchor('Heading Text', 'custom', 0),
     { message: 'Missing href' }
+  );
+  t.end();
+})
+
+test('\ninvalid input for mode throws', function (t) {
+  t.throws(
+    () => anchor('Heading Text', 'random'),
+    { message: 'Unknown mode: random' }
   );
   t.end();
 })

--- a/test/anchor-markdown-header.js
+++ b/test/anchor-markdown-header.js
@@ -187,3 +187,15 @@ test('\ngenerating anchor for non-english header', function (t) {
   ].forEach(function (x) { check(x[0], x[1], x[2]) });
   t.end();
 })
+
+test('\ngenerating anchor in custom mode', function (t) {
+  var actual = anchor('custom', 'Heading Text', 0, 'head');
+  var expectedAnchor = '[Heading Text](#head)';
+  t.equal(actual, expectedAnchor);
+})
+
+test('\ngenerating anchor in github mode with href', function (t) {
+  var actual = anchor('github', 'Heading Text', 1, 'head');
+  var expectedAnchor = '[Heading Text](#head)';
+  t.equal(actual, expectedAnchor);
+})


### PR DESCRIPTION
Closes #62 

This adds a new custom mode which enables the calling application to specify the href and automatically use custom if href is supplied.