### PR TITLE
feat: expose anchor name

### DIFF
--- a/anchor-markdown-header.js
+++ b/anchor-markdown-header.js
@@ -119,19 +119,11 @@ function getGitlabId(text, repetition) {
  * @param href        {String} The href to be used in the anchor.
  * @return            {String} The header anchor that is compatible with the given mode.
  */
-module.exports = function anchorMarkdownHeader(header, mode, repetition, href) {
+module.exports = function anchorMarkdownHeader(header, mode, repetition) {
   mode = mode || 'github.com';
   var replace;
   var customEncodeURI = encodeURI;
   var customCasing = asciiOnlyToLowerCase;
-
-  // Extended Markdown heading IDs: `Header text {#id}` or kramdown's `{:#id}` at end of line.
-  // See https://www.markdownlang.com/extended/heading-ids.html
-  var idMatch = header.match(/^(.*?)[ \t]*\{:?#([^\s}]+)\}[ \t]*$/);
-  if (idMatch) {
-    header = idMatch[1];
-    href = idMatch[2];
-  }
 
   switch(mode) {
     case 'github.com':
@@ -162,9 +154,6 @@ module.exports = function anchorMarkdownHeader(header, mode, repetition, href) {
       replace = getGhostId;
       break;
     case 'custom':
-      if(href === undefined){
-        throw new Error('Missing href');
-      }
       break;
     default:
       throw new Error('Unknown mode: ' + mode);
@@ -182,7 +171,7 @@ module.exports = function anchorMarkdownHeader(header, mode, repetition, href) {
     return result;
   }
 
-  href = href || replace(customCasing(header.trim()), repetition);
+  var href = replace(customCasing(header.trim()), repetition);
 
-  return '[' + header + '](#' + customEncodeURI(href) + ')';
+  return customEncodeURI(href);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const anchorName = require('../anchor-markdown-header');
+
+function parse(header) {
+  // Extended Markdown heading IDs: `Header text {#id}` or kramdown's `{:#id}` at end of line.
+  // See https://www.markdownlang.com/extended/heading-ids.html
+  var idMatch = header.match(/^(.*?)[ \t]*\{:?#([^\s}]+)\}[ \t]*$/);
+  return idMatch ? {
+      text: idMatch[1],
+      href: idMatch[2]
+    } : {
+      text: header
+    };
+}
+
+/**
+ * Generates an anchor link for the given header and mode.
+ *
+ * @name anchorLink
+ * @function
+ * @param header      {String} The header to be anchored.
+ * @param href        {String} The href to be used in the anchor.
+ * @return            {String} The header anchor link that is compatible with the given mode.
+ */
+function anchorLink(header, href) {
+  if(href === undefined){
+    throw new Error('Missing href');
+  }
+  return '[' + header + '](#' + href + ')';
+}
+
+/**
+ * Generates an anchor for the given header and mode.
+ *
+ * @name anchor
+ * @function
+ * @param header      {String} The header to be anchored.
+ * @param mode        {String} The anchor mode (github.com|nodejs.org|bitbucket.org|ghost.org|gitlab.com).
+ * @param repetition  {Number} The nth occurrence of this header text, starting with 0. Not required for the 0th instance.
+ * @param href        {String} The href to be used in the anchor.
+ * @return            {object} The header anchor link & name that is compatible with the given mode.
+ */
+function anchor(header, mode, repetition, href) {
+  const parsed = parse(header);
+  if (href === undefined && parsed.href) href = encodeURI(parsed.href);
+  if (href === undefined && mode !== 'custom') href = anchorName(parsed.text, mode, repetition);
+  return {
+    link: anchorLink(parsed.text, href),
+    name: href,
+    text: parsed.text
+  };
+}
+
+// TODO: convert to a proxy call of anchor in v1 bump
+/**
+ * Generates an anchor link for the given header and mode.
+ *
+ * @name anchorMarkdownHeader
+ * @function
+ * @param header      {String} The header to be anchored.
+ * @param mode        {String} The anchor mode (github.com|nodejs.org|bitbucket.org|ghost.org|gitlab.com).
+ * @param repetition  {Number} The nth occurrence of this header text, starting with 0. Not required for the 0th instance.
+ * @param href        {String} The href to be used in the anchor.
+ * @return            {String} The header anchor link that is compatible with the given mode.
+ */
+function anchorMarkdownHeader(header, mode, repetition, href) {
+  const parsed = parse(header);
+  if (href === undefined && parsed.href) href = encodeURI(parsed.href);
+  if (href === undefined && mode !== 'custom') href = anchorName(parsed.text, mode, repetition);
+  return anchorLink(parsed.text, href);
+};
+
+anchorMarkdownHeader.anchorLink = anchorLink;
+anchorMarkdownHeader.anchor = anchor;
+
+module.exports = anchorMarkdownHeader;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "anchor-markdown-header",
   "version": "0.0.0-development",
   "description": "Generates an anchor for a markdown header.",
-  "main": "anchor-markdown-header.js",
+  "main": "lib/index.js",
   "scripts": {
     "test": "tap test/*.js"
   },

--- a/test/anchor-link.js
+++ b/test/anchor-link.js
@@ -1,0 +1,11 @@
+'use strict';
+/*jshint asi:true */
+
+var test   =  require('tap').test;
+const { anchorLink } =  require('../lib');
+
+test('\nanchor link constructed as expected', function (t) {
+  var link = anchorLink('Header', 'link');
+  t.same(link, '[Header](#link)', 'link is correct');
+  t.end();
+});

--- a/test/anchor-markdown-header.js
+++ b/test/anchor-markdown-header.js
@@ -3,7 +3,7 @@
 
 var test   =  require('tap').test
   , format =  require('util').format
-  , anchor =  require('..')
+  , anchor =  require('../lib');
 
 function checkResult(t, mode, header, repetition, href) {
   var expectedAnchor = format('[%s](%s)', header, href)

--- a/test/anchor.js
+++ b/test/anchor.js
@@ -1,0 +1,12 @@
+'use strict';
+/*jshint asi:true */
+
+var test   =  require('tap').test;
+const { anchor } =  require('../lib');
+
+test('\nanchor constructed as expected', function (t) {
+  var anchorDetails = anchor('Header');
+  t.same(anchorDetails.link, '[Header](#header)', 'link is correct');
+  t.same(anchorDetails.name, 'header', 'name is correct');
+  t.end();
+});


### PR DESCRIPTION
Closes #71

This refactors the lib to also expose an anchor object containing both the link and name.

This eliminates the need for string splitting in doctoc and provides the foundation for also generating anchor targets #73.